### PR TITLE
Fix: LeetCode #452 Minimum Number of Arrows to Burst Balloons

### DIFF
--- a/src/Leetcode452.java
+++ b/src/Leetcode452.java
@@ -21,4 +21,20 @@ public class Leetcode452 {
         
         return count;
     }
+
+    public int findMinArrowShots2(int[][] points) {
+        if (points.length == 0) return 0;
+
+        Arrays.sort(points, Comparator.comparingInt(a -> a[1]));  
+        int count = 1; 
+        int end = points[0][1]; 
+    
+        for (int i = 1; i < points.length; i++) {
+            if (points[i][0] > end) { 
+                count++;
+                end = points[i][1];
+            }
+        }
+        return count;
+    }
 }


### PR DESCRIPTION
This commit implements two solutions for LeetCode problem #452, which involves determining the minimum number of arrows needed to burst all balloons given their start and end positions.

Both `findMinArrowShots` and `findMinArrowShots2`  implement the same logic:
1. Sort the balloons by their end positions.
2. Iterate through the sorted balloons, using a single arrow if the next balloon's start position is greater than the current arrow's end position, otherwise updating the end position to the minimum of the two balloons.

Changes:
- Implemented two solutions (`findMinArrowShots` and `findMinArrowShots2`) for clarity and potential performance comparisons.